### PR TITLE
no-implicit-dependencies

### DIFF
--- a/Typescript/base.json
+++ b/Typescript/base.json
@@ -12,6 +12,7 @@
     "member-access": false,
     "no-bitwise": false,
     "no-console": [true, "warn"],
+    "no-implicit-dependencies": [true, "dev"],
     "no-reference": false,
     "no-string-literal": false,
     "no-trailing-whitespace": false,

--- a/Typescript/base.json
+++ b/Typescript/base.json
@@ -12,7 +12,7 @@
     "member-access": false,
     "no-bitwise": false,
     "no-console": [true, "warn"],
-    "no-implicit-dependencies": [true, "dev"],
+    "no-implicit-dependencies": [true, "dev", "optional"],
     "no-reference": false,
     "no-string-literal": false,
     "no-trailing-whitespace": false,


### PR DESCRIPTION
added config for newly enabled rule: [no-implicit-dependencies](https://palantir.github.io/tslint/rules/no-implicit-dependencies/)
The rule validates that you have all your modules in `package.json` but it doesn't check `devDependencies` by default. This means if you use tslint to check your tests, tslint will throw an error similar to this: `ERROR: tests/client.spec.ts[1, 32]: Module 'chai' is not listed as dependency in package.json`