### PR TITLE
Suggestions from the Tsunami Team

### DIFF
--- a/Typescript/base.json
+++ b/Typescript/base.json
@@ -13,7 +13,7 @@
     "max-classes-per-file": false,
     "member-access": false,
     "no-angle-bracket-type-assertion": false,
-    "no-any": true,
+    "no-any": { "severity": "warning" },
     "no-async-without-await": true,
     "no-bitwise": false,
     "no-console": [true, "warn"],

--- a/Typescript/base.json
+++ b/Typescript/base.json
@@ -36,7 +36,7 @@
     "semicolon": [true, "always"],
     "trailing-comma": false,
     "triple-equals": [true, "allow-null-check"],
-    "typedef": [true, "call-signature", "member-variable-declaration", "parameter", "variable-declaration"],
+    "typedef": [true, "call-signature", "parameter"],
     "variable-name": [true, "ban-keywords", "check-format", "allow-leading-underscore"],
     "whitespace": [true, "check-decl", "check-operator", "check-separator", "check-type"]
   },

--- a/Typescript/base.json
+++ b/Typescript/base.json
@@ -2,6 +2,7 @@
   "extends": ["tslint:latest", "tslint-config-security"],
   "rules": {
     "arrow-parens": false,
+    "arrow-return-shorthand": [false],
     "class-name": true,
     "curly": false,
     "eofline": true,
@@ -9,41 +10,35 @@
     "indent": [true, "spaces"],
     "interface-name": false,
     "jsdoc-format": true,
+    "max-classes-per-file": false,
     "member-access": false,
+    "no-angle-bracket-type-assertion": false,
+    "no-any": true,
+    "no-async-without-await": true,
     "no-bitwise": false,
     "no-console": [true, "warn"],
+    "no-floating-promises": true,
     "no-implicit-dependencies": [true, "dev", "optional"],
     "no-reference": false,
     "no-string-literal": false,
+    "no-submodule-imports": false,
     "no-trailing-whitespace": false,
+    "no-unused-expression": [false],
     "no-var-requires": false,
     "object-literal-key-quotes": [true, "as-needed"],
     "object-literal-sort-keys": false,
     "only-arrow-functions": false,
     "ordered-imports": false,
+    "prefer-conditional-expression": false,
     "prefer-for-of": false,
+    "prefer-object-spread": false,
     "quotemark": [true, "single"],
     "semicolon": [true, "always"],
     "trailing-comma": false,
     "triple-equals": [true, "allow-null-check"],
+    "typedef": [true, "call-signature", "member-variable-declaration", "parameter", "variable-declaration"],
     "variable-name": [true, "ban-keywords", "check-format", "allow-leading-underscore"],
-    "prefer-object-spread": false,
-    "prefer-conditional-expression": false,
-    "whitespace": [true,
-      "check-decl",
-      "check-operator",
-      "check-separator",
-      "check-type"
-    ],
-    "max-classes-per-file": false,
-    "no-angle-bracket-type-assertion": false,
-    "no-submodule-imports": false,
-    "no-unused-expression": [
-      false
-    ],
-    "arrow-return-shorthand": [
-      false
-    ]
+    "whitespace": [true, "check-decl", "check-operator", "check-separator", "check-type"]
   },
   "rulesDirectory": []
 }

--- a/Typescript/package.json
+++ b/Typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tslint-config-swimlane",
-  "version": "4.0.0",
-  "description": "Linting rules for Typescript 2",
+  "version": "5.0.0",
+  "description": "Linting rules for Typescript",
   "main": "base.json",
   "repository": {
     "type": "git",


### PR DESCRIPTION
(I sorted the rules to be easier to read, but that makes the diff a little messier. Should be less messy in the future if we keep the rules sorted)

The Tsunami team would like to suggest the following additions to the Typescript linting rules:
- ["no-any": { "severity": "warning" }](https://palantir.github.io/tslint/rules/no-any/): We would like to avoid `any` if at all possible. This rule would show a warning with `any` is used.
- ["no-async-without-await": true](https://palantir.github.io/tslint/rules/no-async-without-await/): This rule would help cleanup unnecessary Promise generation
- ["no-floating-promises": true](https://palantir.github.io/tslint/rules/no-floating-promises/): Avoid uncaught promises rejects or other unexpected behavior. This can be overridden where needed.
- ["typedef": \[true, "call-signature", "parameter"\]](https://palantir.github.io/tslint/rules/typedef/): They would like to enforce that type definitions be required for the following items:
  - "call-signature": checks return type of functions
  - "parameter": checks type specifier of function parameters for non-arrow functions